### PR TITLE
Resolve issue with building an apk file on flutter 1.12

### DIFF
--- a/packages/native_pdf_renderer/android/build.gradle
+++ b/packages/native_pdf_renderer/android/build.gradle
@@ -26,7 +26,7 @@ rootProject.allprojects {
 }
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
This resolves an issue with flutter version 1.12 while building apks by updating compileSdkVersion to 28.

The issue is described here: https://github.com/flutter/flutter/issues/46881#issuecomment-565174872