### PR TITLE
use class attribute for initialPage

### DIFF
--- a/packages/native_pdf_view/lib/src/native_pdf_controller.dart
+++ b/packages/native_pdf_view/lib/src/native_pdf_controller.dart
@@ -88,9 +88,8 @@ class PdfController {
   }
 
   Future<void> _loadDocument(
-    Future<PdfDocument> documentFuture, {
-    int initialPage = 1,
-  }) async {
+    Future<PdfDocument> documentFuture,
+  ) async {
     assert(_pdfViewState != null);
 
     if (!await hasSupport()) {


### PR DESCRIPTION
In the _loadDocument function, it was taking in a named argument of initialPage with a default value of 1. 
However,  the PdfController class has an attribute for the initialPage that also has a default value of 1. 

Furthermore, in the _attach and public loadDocument functions, _loadDocument was called without the initialPage argument, causing the default value of 1 to be used even if the PdfController was passed an initialPage value in the constructor.

```Dart
PdfController({
    @required this.document,
    this.initialPage = 1, // <----------
    this.viewportFraction = 1.0,
  })  : assert(initialPage != null),
        assert(viewportFraction != null),
        assert(viewportFraction > 0.0);
```

```Dart
Future<void> loadDocument(Future<PdfDocument> documentFuture) {
    _pdfViewState._changeLoadingState(_PdfViewLoadingState.loading);
    return _loadDocument(documentFuture); // <----------
  }
```

```Dart
void _attach(_PdfViewState pdfViewState) {
    if (_pdfViewState != null) {
      return;
    }

    _reInitPageController(initialPage);

    _pdfViewState = pdfViewState;

    if (_document == null) {
      _loadDocument(document); // <----------
    }
  }
````