### PR TITLE
Transfer image back to Flutter via temporary file (Android)

### DIFF
--- a/packages/native_pdf_renderer/android/src/main/kotlin/io/scer/pdf/renderer/NativePdfRendererPlugin.kt
+++ b/packages/native_pdf_renderer/android/src/main/kotlin/io/scer/pdf/renderer/NativePdfRendererPlugin.kt
@@ -178,7 +178,7 @@ class NativePdfRendererPlugin(private val registrar: Registrar) : MethodCallHand
                 }
                 val tempOutFile = File(registrar.context().cacheDir, "$randomFilename.$tempOutFileExtension")
 
-                val results = page.render(width, height, color, format, crop, cropX, cropY, cropW, cropH, quality).toMap
+                val results = page.render(tempOutFile, width, height, color, format, crop, cropX, cropY, cropW, cropH, quality).toMap
                 result.success(results)
 
             } catch (e: Exception) {

--- a/packages/native_pdf_renderer/android/src/main/kotlin/io/scer/pdf/renderer/document/Page.kt
+++ b/packages/native_pdf_renderer/android/src/main/kotlin/io/scer/pdf/renderer/document/Page.kt
@@ -5,6 +5,7 @@ import android.graphics.Bitmap
 import android.graphics.pdf.PdfRenderer
 import android.os.Build
 import io.scer.pdf.renderer.utils.toByteArray
+import io.scer.pdf.renderer.utils.toFile
 import java.io.File
 
 @TargetApi(Build.VERSION_CODES.LOLLIPOP)

--- a/packages/native_pdf_renderer/android/src/main/kotlin/io/scer/pdf/renderer/document/Page.kt
+++ b/packages/native_pdf_renderer/android/src/main/kotlin/io/scer/pdf/renderer/document/Page.kt
@@ -5,12 +5,13 @@ import android.graphics.Bitmap
 import android.graphics.pdf.PdfRenderer
 import android.os.Build
 import io.scer.pdf.renderer.utils.toByteArray
+import java.io.File
 
 @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-class Page (
-        private val id: String,
-        private val documentId: String,
-        private val pageRenderer: PdfRenderer.Page
+class Page(
+    private val id: String,
+    private val documentId: String,
+    private val pageRenderer: PdfRenderer.Page
 ) {
     /** Page number in document */
     private val number: Int get() = pageRenderer.index
@@ -18,55 +19,59 @@ class Page (
     private val width: Int get() = pageRenderer.width
     private val height: Int get() = pageRenderer.height
 
-    val infoMap: Map<String, Any> get() =
-         mapOf(
-             "documentId" to documentId,
-             "id" to id,
-             "pageNumber" to number,
-             "width" to width,
-             "height" to height
-        )
+    val infoMap: Map<String, Any>
+        get() =
+            mapOf(
+                "documentId" to documentId,
+                "id" to id,
+                "pageNumber" to number,
+                "width" to width,
+                "height" to height
+            )
 
     fun close() {
         pageRenderer.close()
     }
 
-    fun render(width: Int, height: Int, background: Int, format: Int, crop: Boolean, cropX: Int, cropY: Int, cropW: Int, cropH: Int): Data {
+    fun render(file: File, width: Int, height: Int, background: Int, format: Int, crop: Boolean, cropX: Int, cropY: Int, cropW: Int, cropH: Int, quality: Int): Data {
         val bitmap = Bitmap.createBitmap(
-                width,
-                height,
-                Bitmap.Config.ARGB_8888)
+            width,
+            height,
+            Bitmap.Config.ARGB_8888)
         bitmap.eraseColor(background)
 
         pageRenderer.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
 
-        if (crop && (cropW != width || cropH != height)){
+        if (crop && (cropW != width || cropH != height)) {
             val cropped = Bitmap.createBitmap(bitmap, cropX, cropY, cropW, cropH)
+            cropped.toFile(file, format, quality)
             return Data(
                 cropW,
                 cropH,
-                data = cropped.toByteArray(format)
+                file.absolutePath
             )
         } else {
+            bitmap.toFile(file, format, quality)
             return Data(
                 width,
                 height,
-                data = bitmap.toByteArray(format)
+                file.absolutePath
             )
         }
     }
 
     data class Data(
-            val width: Int,
-            val height: Int,
-            val data: ByteArray
+        val width: Int,
+        val height: Int,
+        val path: String
     ) {
-        val toMap: Map<String, Any> get() =
-            mapOf(
+        val toMap: Map<String, Any>
+            get() =
+                mapOf(
                     "width" to width,
                     "height" to height,
-                    "data" to data
-            )
+                    "path" to path
+                )
 
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
@@ -74,11 +79,13 @@ class Page (
 
             other as Data
 
-            if (!data.contentEquals(other.data)) return false
+            if (!path.contentEquals(other.path)) return false
 
             return true
         }
 
-        override fun hashCode(): Int = data.contentHashCode()
+        override fun hashCode(): Int = width.hashCode()
+            .times(31).plus(height.hashCode())
+            .times(31).plus(path.hashCode())
     }
 }

--- a/packages/native_pdf_renderer/android/src/main/kotlin/io/scer/pdf/renderer/utils/CompressFormats.kt
+++ b/packages/native_pdf_renderer/android/src/main/kotlin/io/scer/pdf/renderer/utils/CompressFormats.kt
@@ -1,0 +1,12 @@
+package io.scer.pdf.renderer.utils
+
+import android.graphics.Bitmap
+
+fun parseCompressFormat(format: Int): Bitmap.CompressFormat {
+    return when(format) {
+        0 -> Bitmap.CompressFormat.JPEG
+        1 -> Bitmap.CompressFormat.PNG
+        2 -> Bitmap.CompressFormat.WEBP
+        else -> Bitmap.CompressFormat.JPEG
+    }
+}

--- a/packages/native_pdf_renderer/android/src/main/kotlin/io/scer/pdf/renderer/utils/Hooks.kt
+++ b/packages/native_pdf_renderer/android/src/main/kotlin/io/scer/pdf/renderer/utils/Hooks.kt
@@ -3,6 +3,7 @@ package io.scer.pdf.renderer.utils
 import android.graphics.Bitmap
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.io.FileOutputStream
 import java.io.InputStream
 
 fun InputStream.toFile(file: File) {
@@ -12,9 +13,10 @@ fun InputStream.toFile(file: File) {
 /**
  * Save bitmap to file
  */
-fun Bitmap.toFile(file: File): File {
-    val stream = file.outputStream()
-    this.compress(Bitmap.CompressFormat.PNG, 100, stream)
+fun Bitmap.toFile(file: File, format: Int, quality: Int = 100): File {
+    val stream = FileOutputStream(file, false)
+    val compressFormat = parseCompressFormat(format)
+    this.compress(compressFormat, quality, stream)
     stream.flush()
     stream.close()
     return file
@@ -25,13 +27,7 @@ fun Bitmap.toFile(file: File): File {
  */
 fun Bitmap.toByteArray(format: Int): ByteArray {
     val stream = ByteArrayOutputStream()
-    val compressFormat: Bitmap.CompressFormat = when(format) {
-        0 -> Bitmap.CompressFormat.JPEG
-        1 -> Bitmap.CompressFormat.PNG
-        2 -> Bitmap.CompressFormat.WEBP
-        else -> Bitmap.CompressFormat.JPEG
-    }
-
+    val compressFormat = parseCompressFormat(format)
     this.compress(compressFormat, 100, stream)
     return stream.toByteArray()
 }

--- a/packages/native_pdf_renderer/example/android/build.gradle
+++ b/packages/native_pdf_renderer/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/packages/native_pdf_renderer/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/native_pdf_renderer/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jun 23 08:50:38 CEST 2017
+#Mon Jan 25 14:48:55 CET 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip

--- a/packages/native_pdf_renderer/lib/src/page.dart
+++ b/packages/native_pdf_renderer/lib/src/page.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data' show Uint8List;
+import 'dart:ui';
 
 import 'package:extension/enum.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
 import 'package:synchronized/synchronized.dart';
@@ -64,12 +64,14 @@ class PdfPage {
   /// [backgroundColor] property like a hex string ('#FFFFFF')
   /// [format] - image type, all types can be seen here [PdfPageFormat]
   /// [cropRect] - render only the necessary part of the image
+  /// [quality] - hint to the JPEG and WebP compression algorithms (0-100)
   Future<PdfPageImage> render({
     @required int width,
     @required int height,
     PdfPageFormat format = PdfPageFormat.PNG,
     String backgroundColor,
     Rect cropRect,
+    int quality = 100,
   }) =>
       _lock.synchronized<PdfPageImage>(() async {
         if (document.isClosed) {
@@ -86,6 +88,7 @@ class PdfPage {
           format: format,
           backgroundColor: backgroundColor,
           crop: cropRect,
+          quality: quality,
         );
       });
 

--- a/packages/native_pdf_renderer/pubspec.lock
+++ b/packages/native_pdf_renderer/pubspec.lock
@@ -21,42 +21,42 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.5.0-nullsafety.3"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0-nullsafety.3"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0-nullsafety.5"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0-nullsafety.3"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0-nullsafety.3"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.15.0-nullsafety.5"
   convert:
     dependency: transitive
     description:
@@ -98,7 +98,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0-nullsafety.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -127,28 +127,28 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.2"
+    version: "0.6.3-nullsafety.3"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.10-nullsafety.3"
   meta:
     dependency: "direct main"
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0-nullsafety.6"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.8.0-nullsafety.3"
   pedantic:
     dependency: "direct dev"
     description:
@@ -181,28 +181,28 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.0-nullsafety.4"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.1"
+    version: "1.10.0-nullsafety.6"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0-nullsafety.3"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0-nullsafety.3"
   synchronized:
     dependency: "direct main"
     description:
@@ -216,21 +216,21 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0-nullsafety.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.2"
+    version: "0.2.19-nullsafety.6"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0-nullsafety.5"
   uuid:
     dependency: "direct main"
     description:
@@ -244,7 +244,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0-nullsafety.5"
   xml:
     dependency: transitive
     description:
@@ -253,5 +253,5 @@ packages:
     source: hosted
     version: "4.5.1"
 sdks:
-  dart: ">=2.10.0-110 <2.11.0"
+  dart: ">=2.12.0-0.0 <3.0.0"
   flutter: ">=1.17.0 <2.0.0"


### PR DESCRIPTION
The API has been retained with full backwards compatibility.
The quality parameter has also been added to be able to control JPEG/WebP quality hint (0-100).

***NOTE:** I played around a little bit with the Matrix transformation on the PDF render function. It seems likely that by accepting a raw Matrix4 in Flutter, we could offer the maximum flexibility while at the same time solve the "cropping issue" where someone wants to render just a specific section of the PDF. That could be a replacement for `cropRect`.*