### PR TITLE
Update epub_controller.dart

### DIFF
--- a/packages/epub_view/lib/src/epub_controller.dart
+++ b/packages/epub_view/lib/src/epub_controller.dart
@@ -145,7 +145,7 @@ class EpubController {
       _epubViewState._changeLoadingState(_EpubViewLoadingState.success);
     } catch (error) {
       _epubViewState
-        .._loadingError = error
+        .._loadingError = e is Exception ? e : Exception('An unexpected error occurred')
         .._changeLoadingState(_EpubViewLoadingState.error);
     }
   }

--- a/packages/epub_view/lib/src/epub_controller.dart
+++ b/packages/epub_view/lib/src/epub_controller.dart
@@ -145,7 +145,7 @@ class EpubController {
       _epubViewState._changeLoadingState(_EpubViewLoadingState.success);
     } catch (error) {
       _epubViewState
-        .._loadingError = e is Exception ? e : Exception('An unexpected error occurred')
+        .._loadingError = error is Exception ? error : Exception('An unexpected error occurred')
         .._changeLoadingState(_EpubViewLoadingState.error);
     }
   }


### PR DESCRIPTION
Errors are not exceptions so casting them to ones is not possible which throws another exception