### PR TITLE
Update epub_cfi_reader.dart

### DIFF
--- a/packages/epub_view/lib/src/epub_cfi_reader.dart
+++ b/packages/epub_view/lib/src/epub_cfi_reader.dart
@@ -124,14 +124,18 @@ class EpubCfiReader {
     if (chapter == null) {
       return null;
     }
-
+    var html = chapter.HtmlContent;
+    html = html.replaceAllMapped(RegExp(r'<\s*([^\s>]+)([^>]*)\/\s*>'),
+            (match) {
+          return '<${match.group(1)}${match.group(2)}></${match.group(1)}>';
+        });
     final regExp = RegExp(
       r'<body.*?>.+?</body>',
       caseSensitive: false,
       multiLine: true,
       dotAll: true,
     );
-    final matches = regExp.firstMatch(chapter.HtmlContent);
+    final matches = regExp.firstMatch(html);
 
     return parse(matches.group(0));
   }


### PR DESCRIPTION
Self ending tags are not supported.
The parser makes them wrap their next siblings.