### PR TITLE
Support for sound null safety via the dart migration tool.

### DIFF
--- a/packages/native_pdf_renderer/example/ios/Flutter/Flutter.podspec
+++ b/packages/native_pdf_renderer/example/ios/Flutter/Flutter.podspec
@@ -1,18 +1,18 @@
 #
 # NOTE: This podspec is NOT to be published. It is only used as a local source!
+#       This is a generated file; do not edit or check into version control.
 #
 
 Pod::Spec.new do |s|
   s.name             = 'Flutter'
   s.version          = '1.0.0'
   s.summary          = 'High-performance, high-fidelity mobile apps.'
-  s.description      = <<-DESC
-Flutter provides an easy and productive way to build and deploy high-performance mobile apps for Android and iOS.
-                       DESC
   s.homepage         = 'https://flutter.io'
   s.license          = { :type => 'MIT' }
   s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
   s.source           = { :git => 'https://github.com/flutter/engine', :tag => s.version.to_s }
   s.ios.deployment_target = '8.0'
-  s.vendored_frameworks = 'Flutter.framework'
+  # Framework linking is handled by Flutter tooling, not CocoaPods.
+  # Add a placeholder to satisfy `s.dependency 'Flutter'` plugin podspecs.
+  s.vendored_frameworks = 'path/to/nothing'
 end

--- a/packages/native_pdf_renderer/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/native_pdf_renderer/example/ios/Runner.xcodeproj/project.pbxproj
@@ -217,12 +217,15 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/device_info/device_info.framework",
+				"${BUILT_PRODUCTS_DIR}/native_pdf_renderer/native_pdf_renderer.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/device_info.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/native_pdf_renderer.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/packages/native_pdf_renderer/example/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/packages/native_pdf_renderer/example/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:Runner.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/packages/native_pdf_renderer/example/lib/main.dart
+++ b/packages/native_pdf_renderer/example/lib/main.dart
@@ -88,20 +88,20 @@ class ExampleApp extends StatelessWidget {
 
 class ImageLoader extends StatelessWidget {
   ImageLoader({
-    @required this.storage,
-    @required this.document,
-    @required this.pageNumber,
-    Key key,
+    required this.storage,
+    required this.document,
+    required this.pageNumber,
+    Key? key,
   }) : super(key: key);
 
-  final Map<int, PdfPageImage> storage;
-  final PdfDocument document;
+  final Map<int, PdfPageImage?> storage;
+  final PdfDocument? document;
   final int pageNumber;
 
   @override
   Widget build(BuildContext context) => FutureBuilder(
         future: _renderPage(),
-        builder: (context, AsyncSnapshot<PdfPageImage> snapshot) {
+        builder: (context, AsyncSnapshot<PdfPageImage?> snapshot) {
           if (snapshot.hasError) {
             return Center(
               child: Text('Error'),
@@ -114,19 +114,19 @@ class ImageLoader extends StatelessWidget {
           }
 
           return Image(
-            image: MemoryImage(snapshot.data.bytes),
+            image: MemoryImage(snapshot.data!.bytes),
           );
         },
       );
 
-  Future<PdfPageImage> _renderPage() async {
+  Future<PdfPageImage?> _renderPage() async {
     if (storage.containsKey(pageNumber)) {
       return storage[pageNumber];
     }
-    final page = await document.getPage(pageNumber);
+    final page = await document!.getPage(pageNumber);
     final pageImage = await page.render(
-      width: page.width * 2,
-      height: page.height * 2,
+      width: page.width! * 2,
+      height: page.height! * 2,
       format: PdfPageFormat.PNG,
     );
     await page.close();

--- a/packages/native_pdf_renderer/example/pubspec.yaml
+++ b/packages/native_pdf_renderer/example/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: 'none'
 
 environment:
-  sdk: '>=2.6.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:

--- a/packages/native_pdf_renderer/lib/src/document.dart
+++ b/packages/native_pdf_renderer/lib/src/document.dart
@@ -9,9 +9,9 @@ import 'page.dart';
 /// PDF page image renderer
 class PdfDocument {
   PdfDocument._({
-    @required this.sourceName,
-    @required this.id,
-    @required this.pagesCount,
+    required this.sourceName,
+    required this.id,
+    required this.pagesCount,
   });
 
   static const MethodChannel _channel = MethodChannel('io.scer.pdf.renderer');
@@ -24,11 +24,11 @@ class PdfDocument {
 
   /// Document unique id.
   /// Generated when opening document.
-  final String id;
+  final String? id;
 
   /// All pages count in document.
   /// Starts from 1.
-  final int pagesCount;
+  final int? pagesCount;
 
   /// Is the document closed
   bool isClosed = false;
@@ -47,59 +47,59 @@ class PdfDocument {
   static PdfDocument _open(Map<dynamic, dynamic> obj, String sourceName) =>
       PdfDocument._(
         sourceName: sourceName,
-        id: obj['id'] as String,
-        pagesCount: obj['pagesCount'] as int,
+        id: obj['id'] as String?,
+        pagesCount: obj['pagesCount'] as int?,
       );
 
   /// Open PDF document from filesystem path
   static Future<PdfDocument> openFile(String filePath) async => _open(
-        await _channel.invokeMethod<Map<dynamic, dynamic>>(
+        await (_channel.invokeMethod<Map<dynamic, dynamic>>(
           'open.document.file',
           filePath,
-        ),
+        ) as FutureOr<Map<dynamic, dynamic>>),
         'file:$filePath',
       );
 
   /// Open PDF document from application assets
   static Future<PdfDocument> openAsset(String name) async => _open(
-        await _channel.invokeMethod<Map<dynamic, dynamic>>(
+        await (_channel.invokeMethod<Map<dynamic, dynamic>>(
           'open.document.asset',
           name,
-        ),
+        ) as FutureOr<Map<dynamic, dynamic>>),
         'asset:$name',
       );
 
   /// Open PDF file from memory (Uint8List)
   static Future<PdfDocument> openData(Uint8List data) async => _open(
-        await _channel.invokeMethod<Map<dynamic, dynamic>>(
+        await (_channel.invokeMethod<Map<dynamic, dynamic>>(
           'open.document.data',
           data,
-        ),
+        ) as FutureOr<Map<dynamic, dynamic>>),
         'memory:$data',
       );
 
   /// Get page object. The first page is 1.
   Future<PdfPage> getPage(int pageNumber) async {
-    if (pageNumber < 1 || pageNumber > pagesCount) {
+    if (pageNumber < 1 || pageNumber > pagesCount!) {
       throw PdfPageNotFoundException();
     }
     return _lock.synchronized<PdfPage>(() async {
       if (isClosed) {
         throw PdfDocumentAlreadyClosedException();
       }
-      final obj = await _channel.invokeMethod<Map<dynamic, dynamic>>(
+      final obj = await (_channel.invokeMethod<Map<dynamic, dynamic>>(
         'open.page',
         {
           'documentId': id,
           'page': pageNumber,
         },
-      );
+      ) as FutureOr<Map<dynamic, dynamic>>);
       return PdfPage(
         document: this,
-        id: obj['id'] as String,
+        id: obj['id'] as String?,
         pageNumber: pageNumber,
-        width: obj['width'] as int,
-        height: obj['height'] as int,
+        width: obj['width'] as int?,
+        height: obj['height'] as int?,
         lock: _lock,
       );
     });

--- a/packages/native_pdf_renderer/lib/src/page.dart
+++ b/packages/native_pdf_renderer/lib/src/page.dart
@@ -26,12 +26,12 @@ class PdfPageFormat extends Enum<int> {
 /// which contains a method [render] for rendering into an image
 class PdfPage {
   PdfPage({
-    @required this.document,
-    @required this.id,
-    @required this.pageNumber,
-    @required this.width,
-    @required this.height,
-    @required Lock lock,
+    required this.document,
+    required this.id,
+    required this.pageNumber,
+    required this.width,
+    required this.height,
+    required Lock lock,
   }) : _lock = lock;
 
   static const MethodChannel _channel = MethodChannel('io.scer.pdf.renderer');
@@ -42,17 +42,17 @@ class PdfPage {
 
   /// Page unique id. Needed for rendering and closing page.
   /// Generated when opening page.
-  final String id;
+  final String? id;
 
   /// Page number in document.
   /// Starts from 1.
   final int pageNumber;
 
   /// Page source width in pixels
-  final int width;
+  final int? width;
 
   /// Page source height in pixels
-  final int height;
+  final int? height;
 
   /// Is the page closed
   bool isClosed = false;
@@ -64,14 +64,14 @@ class PdfPage {
   /// [backgroundColor] property like a hex string ('#FFFFFF')
   /// [format] - image type, all types can be seen here [PdfPageFormat]
   /// [cropRect] - render only the necessary part of the image
-  Future<PdfPageImage> render({
-    @required int width,
-    @required int height,
+  Future<PdfPageImage?> render({
+    required int width,
+    required int height,
     PdfPageFormat format = PdfPageFormat.PNG,
-    String backgroundColor,
-    Rect cropRect,
+    String? backgroundColor,
+    Rect? cropRect,
   }) =>
-      _lock.synchronized<PdfPageImage>(() async {
+      _lock.synchronized<PdfPageImage?>(() async {
         if (document.isClosed) {
           throw PdfDocumentAlreadyClosedException();
         } else if (isClosed) {

--- a/packages/native_pdf_renderer/lib/src/page_image.dart
+++ b/packages/native_pdf_renderer/lib/src/page_image.dart
@@ -5,28 +5,28 @@ part of 'page.dart';
 /// of [PdfPage]
 class PdfPageImage {
   const PdfPageImage._({
-    @required this.id,
-    @required this.pageNumber,
-    @required this.width,
-    @required this.height,
-    @required this.bytes,
-    @required this.format,
+    required this.id,
+    required this.pageNumber,
+    required this.width,
+    required this.height,
+    required this.bytes,
+    required this.format,
   });
 
   static const MethodChannel _channel = MethodChannel('io.scer.pdf.renderer');
 
   /// Page unique id. Needed for rendering and closing page.
   /// Generated when render page.
-  final String id;
+  final String? id;
 
   /// Page number. The first page is 1.
   final int pageNumber;
 
   /// Width of the rendered area in pixels.
-  final int width;
+  final int? width;
 
   /// Height of the rendered area in pixels.
-  final int height;
+  final int? height;
 
   /// Image bytes
   final Uint8List bytes;
@@ -41,14 +41,14 @@ class PdfPageImage {
   /// [backgroundColor] property like a hex string ('#000000')
   /// [format] - image type, all types can be seen here [PdfPageFormat]
   /// [crop] - render only the necessary part of the image
-  static Future<PdfPageImage> _render({
-    @required String pageId,
-    @required int pageNumber,
-    @required int width,
-    @required int height,
-    @required PdfPageFormat format,
-    @required String backgroundColor,
-    @required Rect crop,
+  static Future<PdfPageImage?> _render({
+    required String? pageId,
+    required int pageNumber,
+    required int width,
+    required int height,
+    required PdfPageFormat format,
+    required String? backgroundColor,
+    required Rect? crop,
   }) async {
     if (format == PdfPageFormat.WEBP && Platform.isIOS) {
       throw PdfNotSupportException(
@@ -76,7 +76,7 @@ class PdfPageImage {
       return null;
     }
 
-    final retWidth = obj['width'] as int, retHeight = obj['height'] as int;
+    final retWidth = obj['width'] as int?, retHeight = obj['height'] as int?;
     final pixels = Uint8List.fromList(obj['data']);
 
     return PdfPageImage._(

--- a/packages/native_pdf_renderer/lib/src/web/document/document.dart
+++ b/packages/native_pdf_renderer/lib/src/web/document/document.dart
@@ -5,8 +5,8 @@ import 'package:native_pdf_renderer/src/web/pdfjs.dart';
 
 class Document {
   Document({
-    @required this.id,
-    @required this.document,
+    required this.id,
+    required this.document,
   });
 
   final String id;
@@ -21,6 +21,6 @@ class Document {
 
   void close() {}
 
-  Future<PdfJsPage> openPage(int pageNumber) =>
+  Future<PdfJsPage> openPage(int? pageNumber) =>
       promiseToFuture<PdfJsPage>(document.getPage(pageNumber));
 }

--- a/packages/native_pdf_renderer/lib/src/web/document/page.dart
+++ b/packages/native_pdf_renderer/lib/src/web/document/page.dart
@@ -10,12 +10,12 @@ import 'package:native_pdf_renderer/src/web/pdfjs.dart';
 
 class Page {
   Page({
-    @required this.id,
-    @required this.documentId,
-    @required this.page,
+    required this.id,
+    required this.documentId,
+    required this.page,
   }) : _viewport = page.getViewport(Settings()..scale = 1.0);
 
-  final String id, documentId;
+  final String? id, documentId;
   final PdfJsPage page;
   final PdfJsViewport _viewport;
 
@@ -35,12 +35,12 @@ class Page {
   void close() {}
 
   Future<Data> render({
-    int width,
-    int height,
+    required int width,
+    int? height,
   }) async {
     final html.CanvasElement canvas =
         js.context['document'].createElement('canvas');
-    final html.CanvasRenderingContext2D context = canvas.getContext('2d');
+    final html.CanvasRenderingContext2D? context = canvas.getContext('2d') as html.CanvasRenderingContext2D?;
 
     final viewport =
         page.getViewport(Settings()..scale = width / _viewport.width);
@@ -62,7 +62,7 @@ class Page {
     final reader = html.FileReader()..readAsArrayBuffer(blob);
     reader.onLoadEnd.listen(
       (html.ProgressEvent e) {
-        data.add(reader.result);
+        data.add(reader.result as List<int>);
         completer.complete();
       },
     );
@@ -78,12 +78,12 @@ class Page {
 
 class Data {
   const Data({
-    @required this.width,
-    @required this.height,
-    @required this.data,
+    required this.width,
+    required this.height,
+    required this.data,
   });
 
-  final int width, height;
+  final int? width, height;
   final Uint8List data;
 
   Map<String, dynamic> get toMap => {

--- a/packages/native_pdf_renderer/lib/src/web/native_pdf_renderer_plugin.dart
+++ b/packages/native_pdf_renderer/lib/src/web/native_pdf_renderer_plugin.dart
@@ -71,30 +71,30 @@ class NativePdfRendererPlugin {
   }
 
   Future<Map<String, dynamic>> openPageHandler(MethodCall call) async {
-    final String documentId = call.arguments['documentId'];
-    final int pageNumber = call.arguments['page'];
-    final page = await _documents.get(documentId).openPage(pageNumber);
+    final String? documentId = call.arguments['documentId'];
+    final int? pageNumber = call.arguments['page'];
+    final page = await _documents.get(documentId)!.openPage(pageNumber);
     return _pages.register(documentId, page).infoMap;
   }
 
   Future<bool> closeDocumentHandler(MethodCall call) async {
-    final String id = call.arguments;
+    final String? id = call.arguments;
     _documents.close(id);
     return true;
   }
 
   Future<bool> closePageHandler(MethodCall call) async {
-    final String id = call.arguments;
+    final String? id = call.arguments;
     _pages.close(id);
     return true;
   }
 
   Future<Map<String, dynamic>> renderHandler(MethodCall call) async {
-    final String pageId = call.arguments['pageId'];
+    final String? pageId = call.arguments['pageId'];
     final int width = call.arguments['width'];
-    final int height = call.arguments['height'];
+    final int? height = call.arguments['height'];
 
-    final page = _pages.get(pageId);
+    final page = _pages.get(pageId)!;
     final result = await page.render(
       width: width,
       height: height,

--- a/packages/native_pdf_renderer/lib/src/web/pdfjs.dart
+++ b/packages/native_pdf_renderer/lib/src/web/pdfjs.dart
@@ -34,7 +34,7 @@ class PdfJs {
 class Settings {
   external set data(Uint8List value);
   external set scale(double value);
-  external set canvasContext(CanvasRenderingContext2D value);
+  external set canvasContext(CanvasRenderingContext2D? value);
   external set viewport(PdfJsViewport value);
 }
 
@@ -47,7 +47,7 @@ class PdfJsDocLoader {
 @anonymous
 @JS()
 class PdfJsDoc {
-  external Future<PdfJsPage> getPage(int num);
+  external Future<PdfJsPage> getPage(int? num);
   external int get numPages;
 }
 

--- a/packages/native_pdf_renderer/lib/src/web/resources/document_repository.dart
+++ b/packages/native_pdf_renderer/lib/src/web/resources/document_repository.dart
@@ -17,8 +17,8 @@ class DocumentRepository extends Repository<Document> {
   }
 
   @override
-  void close(String id) {
-    get(id).close();
+  void close(String? id) {
+    get(id)!.close();
     super.close(id);
   }
 }

--- a/packages/native_pdf_renderer/lib/src/web/resources/page_repository.dart
+++ b/packages/native_pdf_renderer/lib/src/web/resources/page_repository.dart
@@ -7,7 +7,7 @@ final Uuid uuid = Uuid();
 
 class PageRepository extends Repository<Page> {
   /// Register document in repository
-  Page register(String documentId, PdfJsPage renderer) {
+  Page register(String? documentId, PdfJsPage renderer) {
     final page = Page(
       id: uuid.v1(),
       documentId: documentId,
@@ -18,8 +18,8 @@ class PageRepository extends Repository<Page> {
   }
 
   @override
-  void close(String id) {
-    get(id).close();
+  void close(String? id) {
+    get(id)!.close();
     super.close(id);
   }
 }

--- a/packages/native_pdf_renderer/lib/src/web/resources/repository.dart
+++ b/packages/native_pdf_renderer/lib/src/web/resources/repository.dart
@@ -1,23 +1,23 @@
 import 'package:meta/meta.dart';
 
 abstract class Repository<T> {
-  final _items = <String, T>{};
+  final _items = <String?, T>{};
 
-  T get(String id) {
+  T? get(String? id) {
     if (!_exist(id)) {
       throw RepositoryItemNotFoundException();
     }
     return _items[id];
   }
 
-  void set(String id, T item) {
+  void set(String? id, T item) {
     _items[id] = item;
   }
 
-  bool _exist(String id) => _items.containsKey(id);
+  bool _exist(String? id) => _items.containsKey(id);
 
   @protected
-  void close(String id) {
+  void close(String? id) {
     _items.remove(id);
   }
 }

--- a/packages/native_pdf_renderer/pubspec.lock
+++ b/packages/native_pdf_renderer/pubspec.lock
@@ -7,98 +7,84 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.13"
-  args:
-    dependency: transitive
-    description:
-      name: args
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.6.0"
+    version: "3.1.2"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
-  convert:
-    dependency: transitive
-    description:
-      name: convert
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.1"
+    version: "1.15.0"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.5"
+    version: "3.0.0"
   device_info:
     dependency: "direct main"
     description:
       name: device_info
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "2.0.0"
   device_info_platform_interface:
     dependency: transitive
     description:
       name: device_info_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.1"
   extension:
     dependency: "direct main"
     description:
       name: extension
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.1"
+    version: "0.2.0-nullsafety.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -120,56 +106,56 @@ packages:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.19"
+    version: "3.0.1"
   js:
     dependency: "direct main"
     description:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.2"
+    version: "0.6.3"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.10"
   meta:
     dependency: "direct main"
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.8.0"
   pedantic:
     dependency: "direct dev"
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.2"
+    version: "1.11.0"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "4.0.2"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "2.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -181,77 +167,77 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.1"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   synchronized:
     dependency: "direct main"
     description:
       name: synchronized
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0+2"
+    version: "3.0.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.2"
+    version: "0.2.19"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   uuid:
     dependency: "direct main"
     description:
       name: uuid
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.2"
+    version: "3.0.1"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
   xml:
     dependency: transitive
     description:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.5.1"
+    version: "5.0.2"
 sdks:
-  dart: ">=2.10.0-110 <2.11.0"
-  flutter: ">=1.17.0 <2.0.0"
+  dart: ">=2.12.0 <3.0.0"
+  flutter: ">=1.17.0"

--- a/packages/native_pdf_renderer/pubspec.yaml
+++ b/packages/native_pdf_renderer/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.4.0
 homepage: https://github.com/rbcprolabs/packages.flutter/tree/master/packages/native_pdf_renderer
 
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
   flutter: '>=1.17.0 <2.0.0'
 
 dependencies:
@@ -12,18 +12,18 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  device_info: ^1.0.0
-  uuid: ^2.2.2
-  image: ^2.1.19
-  js: ^0.6.2
-  meta: ^1.1.8
-  extension: ^0.1.1
-  synchronized: ^2.2.0+2
+  device_info: ^2.0.0
+  uuid: ^3.0.1
+  image: ^3.0.1
+  js: ^0.6.3
+  meta: ^1.3.0
+  extension: ^0.2.0-nullsafety.0
+  synchronized: ^3.0.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.9.0
+  pedantic: ^1.11.0
 
 flutter:
   plugin:

--- a/packages/native_pdf_renderer/test/native_pdf_renderer_test.dart
+++ b/packages/native_pdf_renderer/test/native_pdf_renderer_test.dart
@@ -1,5 +1,5 @@
 import 'dart:typed_data';
-
+import 'dart:async';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:native_pdf_renderer/native_pdf_renderer.dart';
@@ -11,7 +11,7 @@ final Uint8List _testData = Uint8List.fromList([0, 0, 0, 0, 0, 0, 0, 0]);
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   final List<MethodCall> log = <MethodCall>[];
-  PdfDocument document;
+  PdfDocument? document;
 
   setUpAll(() async {
     MethodChannel('io.scer.pdf.renderer')
@@ -90,21 +90,21 @@ void main() {
           arguments: _testData,
         ),
       ]);
-      expect(document.pagesCount, 3);
+      expect(document!.pagesCount, 3);
     });
   });
 
   group('Page', () {
-    PdfPage page;
+    late PdfPage page;
 
     test('open', () async {
       // page number 0 - not available
       expect(
-        document.getPage(0),
+        document!.getPage(0),
         throwsA(isInstanceOf<PdfPageNotFoundException>()),
       );
 
-      page = await document.getPage(3);
+      page = await document!.getPage(3);
       expect(log, <Matcher>[
         isMethodCall(
           'open.page',
@@ -122,19 +122,19 @@ void main() {
 
       // page number 4 more than the document
       expect(
-        document.getPage(4),
+        document!.getPage(4),
         throwsA(isInstanceOf<PdfPageNotFoundException>()),
       );
     });
 
     test('render', () async {
-      final width = page.width * 2, height = page.height * 2;
-      final pageImage = await page.render(
+      final width = page.width! * 2, height = page.height! * 2;
+      final pageImage = await (page.render(
         width: width,
         height: height,
         format: PdfPageFormat.JPEG,
         backgroundColor: '#ffffff',
-      );
+      ) as FutureOr<PdfPageImage>);
 
       expect(log, <Matcher>[
         isMethodCall(
@@ -176,14 +176,14 @@ void main() {
   });
 
   test('Close document', () async {
-    await document.close();
-    expect(document.isClosed, isTrue);
+    await document!.close();
+    expect(document!.isClosed, isTrue);
     expect(
-      document.close,
+      document!.close,
       throwsA(isInstanceOf<PdfDocumentAlreadyClosedException>()),
     );
     expect(
-      document.getPage(1),
+      document!.getPage(1),
       throwsA(isInstanceOf<PdfDocumentAlreadyClosedException>()),
     );
   });


### PR DESCRIPTION
With the release of Flutter 2, I updated the dependencies for the native_pdf_renderer to the latest versions that support null safety and then ran the `dart migrate` tool to migrate the code base. The same methodology was applied to the `example` project.

This is in support of #147 