### PR TITLE
[native_pdf_renderer] Avoided unnecessary memory usage

### DIFF
--- a/packages/native_pdf_renderer/lib/src/document.dart
+++ b/packages/native_pdf_renderer/lib/src/document.dart
@@ -75,7 +75,7 @@ class PdfDocument {
           'open.document.data',
           data,
         ))!,
-        'memory:$data',
+        'memory:binary',
       );
 
   /// Get page object. The first page is 1.


### PR DESCRIPTION
When rendering pdf docs from a Uint8List, the list was also being unnecessarily converted into a string. This removes that extra conversion to improve performance and save RAM.