### PR TITLE
Fixes issue in flutter web when reAnimateOnVisibility is set to true

### DIFF
--- a/packages/auto_animated/lib/src/animate_if_visible.dart
+++ b/packages/auto_animated/lib/src/animate_if_visible.dart
@@ -99,6 +99,12 @@ class _AnimateIfVisibleState extends State<AnimateIfVisible>
         !info.visibleBounds.isEmpty) {
       _controller.reverse();
     }
+    else if (info.visibleFraction <= widget.visibleFraction &&
+        mounted &&
+        widget.reAnimateOnVisibility &&
+        info.visibleBounds.isEmpty) {
+      _controller.reset();
+    }
   }
 }
 


### PR DESCRIPTION
Fixes the issue on flutter web, that elements that are not visible and whose animation has not been reversed, stay visible when returning back to being visible when reAnimateOnVisibility is set to true