### PR TITLE
cast error while ExplorerLocalizationsDelegate() + french support

### DIFF
--- a/packages/explorer/example/lib/main.dart
+++ b/packages/explorer/example/lib/main.dart
@@ -67,6 +67,7 @@ class _MyAppState extends State<MyApp> {
         supportedLocales: [
           const Locale('en', ''),
           const Locale('ru', ''),
+          const Locale('fr', ''),
         ],
         home: Scaffold(
           body: Explorer(

--- a/packages/explorer/lib/src/i18n/localization_delegate.dart
+++ b/packages/explorer/lib/src/i18n/localization_delegate.dart
@@ -7,7 +7,8 @@ class ExplorerLocalizationsDelegate
   const ExplorerLocalizationsDelegate();
 
   @override
-  bool isSupported(Locale locale) => ['en', 'ru'].contains(locale.languageCode);
+  bool isSupported(Locale locale) =>
+      ['en', 'ru', 'fr'].contains(locale.languageCode);
 
   @override
   Future<ExplorerLocalizations> load(Locale locale) =>

--- a/packages/explorer/lib/src/i18n/messages/messages_all.dart
+++ b/packages/explorer/lib/src/i18n/messages/messages_all.dart
@@ -20,10 +20,10 @@ import 'package:intl/src/intl_helpers.dart';
 import 'messages_en.dart' deferred as messages_en;
 import 'messages_ru.dart' deferred as messages_ru;
 
-typedef Future<Object> LibraryLoader();
+typedef Future<dynamic> LibraryLoader();
 Map<String, LibraryLoader> _deferredLibraries = {
-  'en': messages_en.loadLibrary as Future<Object> Function(),
-  'ru': messages_ru.loadLibrary as Future<Object> Function(),
+  'en': messages_en.loadLibrary,
+  'ru': messages_ru.loadLibrary,
 };
 
 MessageLookupByLibrary? _findExact(String localeName) {

--- a/packages/explorer/lib/src/i18n/messages/messages_all.dart
+++ b/packages/explorer/lib/src/i18n/messages/messages_all.dart
@@ -19,11 +19,13 @@ import 'package:intl/src/intl_helpers.dart';
 
 import 'messages_en.dart' deferred as messages_en;
 import 'messages_ru.dart' deferred as messages_ru;
+import 'messages_fr.dart' deferred as messages_fr;
 
 typedef Future<dynamic> LibraryLoader();
 Map<String, LibraryLoader> _deferredLibraries = {
   'en': messages_en.loadLibrary,
   'ru': messages_ru.loadLibrary,
+  'fr': messages_fr.loadLibrary,
 };
 
 MessageLookupByLibrary? _findExact(String localeName) {
@@ -32,6 +34,8 @@ MessageLookupByLibrary? _findExact(String localeName) {
       return messages_en.messages;
     case 'ru':
       return messages_ru.messages;
+    case 'fr':
+      return messages_fr.messages;
     default:
       return null;
   }

--- a/packages/explorer/lib/src/i18n/messages/messages_fr.dart
+++ b/packages/explorer/lib/src/i18n/messages/messages_fr.dart
@@ -1,0 +1,43 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that provides messages for a en locale. All the
+// messages from the main program should be duplicated here with the same
+// function name.
+
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:unnecessary_brace_in_string_interps, unnecessary_new
+// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
+// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
+// ignore_for_file:unused_import, file_names
+// ignore_for_file: type_annotate_public_apis
+// ignore_for_file: always_declare_return_types
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+
+final messages = new MessageLookup();
+
+typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
+
+class MessageLookup extends MessageLookupByLibrary {
+  String get localeName => 'fr';
+
+  final Map<String, dynamic> messages =
+      _notInlinedMessages(_notInlinedMessages);
+  static _notInlinedMessages(_) => <String, Function>{
+        "actionCopyHere": MessageLookupByLibrary.simpleMessage("Copier ici"),
+        "actionMenuCopy": MessageLookupByLibrary.simpleMessage("Copier"),
+        "actionMenuCut": MessageLookupByLibrary.simpleMessage("Couper"),
+        "actionMenuDelete": MessageLookupByLibrary.simpleMessage("Supprimer"),
+        "actionMenuOpen": MessageLookupByLibrary.simpleMessage("Ouvrir"),
+        "actionMoveHere": MessageLookupByLibrary.simpleMessage("Déplacer ici"),
+        "cancel": MessageLookupByLibrary.simpleMessage("Annuler"),
+        "create": MessageLookupByLibrary.simpleMessage("Créer"),
+        "empty": MessageLookupByLibrary.simpleMessage("Vide"),
+        "fileName": MessageLookupByLibrary.simpleMessage("Nom du fichier"),
+        "folderName": MessageLookupByLibrary.simpleMessage("Nom du dossier"),
+        "newFile": MessageLookupByLibrary.simpleMessage("Nouveau fichier"),
+        "newFolder": MessageLookupByLibrary.simpleMessage("Nouveau dossier"),
+        "uploadFiles":
+            MessageLookupByLibrary.simpleMessage("Upload des fichiers")
+      };
+}

--- a/packages/explorer/lib/src/i18n/messages/messages_fr.dart
+++ b/packages/explorer/lib/src/i18n/messages/messages_fr.dart
@@ -38,6 +38,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "newFile": MessageLookupByLibrary.simpleMessage("Nouveau fichier"),
         "newFolder": MessageLookupByLibrary.simpleMessage("Nouveau dossier"),
         "uploadFiles":
-            MessageLookupByLibrary.simpleMessage("Upload des fichiers")
+            MessageLookupByLibrary.simpleMessage("Ajouter des fichiers")
       };
 }

--- a/packages/explorer/locales/intl_message_fr.arb
+++ b/packages/explorer/locales/intl_message_fr.arb
@@ -40,7 +40,7 @@
   "@newFile": {
     "type": "text"
   },
-  "uploadFiles": "Upload des fichiers",
+  "uploadFiles": "Ajouter des fichiers",
   "@uploadFiles": {
     "type": "text"
   },

--- a/packages/explorer/locales/intl_message_fr.arb
+++ b/packages/explorer/locales/intl_message_fr.arb
@@ -1,0 +1,59 @@
+{
+  "@@locale": "fr",
+  "actionMenuOpen": "Ouvrir",
+  "@actionMenuOpen": {
+    "type": "text"
+  },
+  "actionMenuCopy": "Copier",
+  "@actionMenuCopy": {
+    "type": "text"
+  },
+  "actionMenuCut": "Couper",
+  "@actionMenuCut": {
+    "type": "text"
+  },
+  "actionMenuDelete": "Supprimer",
+  "@actionMenuDelete": {
+    "type": "text"
+  },
+  "actionCopyHere": "Copier ici",
+  "@actionCopyHere": {
+    "type": "text"
+  },
+  "actionMoveHere": "Déplacer ici",
+  "@actionMoveHere": {
+    "type": "text"
+  },
+  "folderName": "Nom du dossier",
+  "@folderName": {
+    "type": "text"
+  },
+  "fileName": "Nom du fichier",
+  "@fileName": {
+    "type": "text"
+  },
+  "newFolder": "Nouveau dossier",
+  "@newFolder": {
+    "type": "text"
+  },
+  "newFile": "Nouveau fichier",
+  "@newFile": {
+    "type": "text"
+  },
+  "uploadFiles": "Upload des fichiers",
+  "@uploadFiles": {
+    "type": "text"
+  },
+  "empty": "Vide",
+  "@empty": {
+    "type": "text"
+  },
+  "cancel": "Annuler",
+  "@cancel": {
+    "type": "text"
+  },
+  "create": "Créer",
+  "@create": {
+    "type": "text"
+  }
+}


### PR DESCRIPTION
fix : `Unhandled Exception: type '() => Future<dynamic>' is not a subtype of type '() => Future<Object>' in type cast`

The explorer pluggin does not work. At least under  (I haven't tried an older version) : 
```
Flutter 2.2.0 • channel stable • https://github.com/flutter/flutter.git
Framework • revision b22742018b (il y a 11 jours) • 2021-05-14 19:12:57 -0700
Engine • revision a9d88a4d18
Tools • Dart 2.13.0
```
A cast error is caused by : `localizationsDelegates: [ExplorerLocalizationsDelegate()]`

I did a quick fix by removing the forced cast to let the dynamic conversion do it.

I know that this code has been generated via `package:intl/generate_localized.dart` but at least now it works.

