### PR TITLE
Update photo_view dependency to 0.12.0

### DIFF
--- a/packages/native_pdf_view/pubspec.lock
+++ b/packages/native_pdf_view/pubspec.lock
@@ -162,7 +162,7 @@ packages:
       name: photo_view
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.1"
+    version: "0.12.0"
   plugin_platform_interface:
     dependency: transitive
     description:

--- a/packages/native_pdf_view/pubspec.yaml
+++ b/packages/native_pdf_view/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  photo_view: ^0.11.1
+  photo_view: ^0.12.0
   synchronized: ^3.0.0
   native_pdf_renderer: ^3.1.0
 


### PR DESCRIPTION
An issue was fixed in the `photo_view` dependency that made it impossible to use with the newest flutter version (2.3, currently in beta). Bumping the dependency here as well.

See https://github.com/fireslime/photo_view/issues/441 for more information

Do I need to update the changelog myself or can you do it when you create a release?