### PR TITLE
Fix for [BUG] 'PointerEvent' can't be assigned to the parameter type 'PointerDownEvent'

### DIFF
--- a/packages/native_pdf_view/pubspec.yaml
+++ b/packages/native_pdf_view/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  photo_view: ^0.11.1
+  photo_view: 0.12.0
   synchronized: ^3.0.0
   native_pdf_renderer: ^3.1.0
 

--- a/packages/native_pdf_view/pubspec.yaml
+++ b/packages/native_pdf_view/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  photo_view: 0.12.0
+  photo_view: ^0.12.0
   synchronized: ^3.0.0
   native_pdf_renderer: ^3.1.0
 


### PR DESCRIPTION
This fixes #202 by updating `photo_view`. I tested the PDF view on both iOS and Android devices with Flutter 2.5.0-1.0.pre (channel dev).