### PR TITLE
Fixed null check operator used on a null value when closing PdfView widget.

### DIFF
--- a/packages/native_pdf_view/lib/src/native_pdf_view.dart
+++ b/packages/native_pdf_view/lib/src/native_pdf_view.dart
@@ -172,7 +172,7 @@ class _PdfViewState extends State<PdfView> with SingleTickerProviderStateMixin {
   Widget _buildLoaded() => PhotoViewGallery.builder(
         builder: (BuildContext context, int index) => widget.pageBuilder(
             _getPageImage(index), index, widget.controller._document!),
-        itemCount: widget.controller._document!.pagesCount,
+        itemCount: widget.controller._document?.pagesCount??0,
         loadingBuilder: (_, __) => widget.pageLoader ?? SizedBox(),
         backgroundDecoration: widget.backgroundDecoration,
         pageController: widget.controller._pageController,


### PR DESCRIPTION
When going back from page having `PdfView()` widget, `null check operator used on a null value` exception is thrown by package. It may be caused by `PdfDocument` gets destroyed before view.

The example with this issue can be reproduced by below:

```dart
class PdfViewPage extends StatelessWidget {
  const PdfViewPage({Key? key, required this.title, required this.pdfUrl})
      : super(key: key);

  final String title;
  final String pdfUrl;

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: Text(title),
      ),
      body: Consumer(builder: (context, watch, child) {
        final pdfPathAsync = watch(invoicePdfStateProvider(pdfUrl));

        return pdfPathAsync.when(
          data: (pdfPath) {
            final pdfController = PdfController(
              document: PdfDocument.openFile(pdfPath),
            );
            return Center(
              child: PdfView(
                controller: pdfController,
              ),
            );
          },
          loading: () => LoadingIndicator(),
          error: (message, _) => ErrorIndicator(message: message.toString()),
        );
      }),
    );
  }
}
```