### PR TITLE
Bump pdfium version and allow host app to overwrite version used

### DIFF
--- a/packages/native_pdf_renderer/README.md
+++ b/packages/native_pdf_renderer/README.md
@@ -158,3 +158,8 @@ This plugin uses the IOS native [CGPDFPage](https://developer.apple.com/document
 
 ### On Windows
 This plugin use [PDFium](https://pdfium.googlesource.com/pdfium/+/master/README.md)
+
+The pdfium version used can be overridden by the base flutter application by adding the following line to the host apps CMakeLists.txt file:
+```
+set(PDFIUM_VERSION "4638" CACHE STRING "")
+```

--- a/packages/native_pdf_renderer/windows/CMakeLists.txt
+++ b/packages/native_pdf_renderer/windows/CMakeLists.txt
@@ -3,12 +3,12 @@ set(PROJECT_NAME "native_pdf_renderer")
 project(${PROJECT_NAME} LANGUAGES CXX)
 
 set(ARCH "x64")
-set(PDFIUM_VERSION "4475")
+set(PDFIUM_VERSION "4638" CACHE STRING "Version of pdfium used")
 
 if(${PDFIUM_VERSION} STREQUAL "latest")
   set(PDFIUM_URL "https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-windows-${ARCH}.zip")
 else()
-  set(PDFIUM_URL "https://github.com/bblanchon/pdfium-binaries/releases/download/chromium%2F${PDFIUM_VERSION}/pdfium-windows-${ARCH}.zip")
+  set(PDFIUM_URL "https://github.com/bblanchon/pdfium-binaries/releases/download/chromium/${PDFIUM_VERSION}/pdfium-windows-${ARCH}.zip")
 endif()
 
 # Download pdfium


### PR DESCRIPTION
* Updates the pdfium version used to the latest stable chromium version
* Provides a mechanism for apps to override this version with a different version

This only affects Windows