### PR TITLE
Fix pdfium version

### DIFF
--- a/packages/native_pdf_renderer/README.md
+++ b/packages/native_pdf_renderer/README.md
@@ -161,5 +161,5 @@ This plugin use [PDFium](https://pdfium.googlesource.com/pdfium/+/master/README.
 
 The pdfium version used can be overridden by the base flutter application by adding the following line to the host apps CMakeLists.txt file:
 ```
-set(PDFIUM_VERSION "4638" CACHE STRING "")
+set(PDFIUM_VERSION "4634" CACHE STRING "")
 ```

--- a/packages/native_pdf_renderer/windows/CMakeLists.txt
+++ b/packages/native_pdf_renderer/windows/CMakeLists.txt
@@ -5,8 +5,12 @@ project(${PROJECT_NAME} LANGUAGES CXX)
 set(ARCH "x64")
 set(PDFIUM_VERSION "4634" CACHE STRING "Version of pdfium used")
 
+string(COMPARE GREATER_EQUAL ${PDFIUM_VERSION} "4690" PDFIUM_BINARY_NEW_FORMAT)
+
 if(${PDFIUM_VERSION} STREQUAL "latest")
-  set(PDFIUM_URL "https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-windows-${ARCH}.zip")
+  set(PDFIUM_URL "https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-win-${ARCH}.tgz")
+elseif(PDFIUM_BINARY_NEW_FORMAT)
+  set(PDFIUM_URL "https://github.com/bblanchon/pdfium-binaries/releases/download/chromium/${PDFIUM_VERSION}/pdfium-win-${ARCH}.tgz")
 else()
   set(PDFIUM_URL "https://github.com/bblanchon/pdfium-binaries/releases/download/chromium/${PDFIUM_VERSION}/pdfium-windows-${ARCH}.zip")
 endif()

--- a/packages/native_pdf_renderer/windows/CMakeLists.txt
+++ b/packages/native_pdf_renderer/windows/CMakeLists.txt
@@ -3,7 +3,7 @@ set(PROJECT_NAME "native_pdf_renderer")
 project(${PROJECT_NAME} LANGUAGES CXX)
 
 set(ARCH "x64")
-set(PDFIUM_VERSION "4638" CACHE STRING "Version of pdfium used")
+set(PDFIUM_VERSION "4634" CACHE STRING "Version of pdfium used")
 
 if(${PDFIUM_VERSION} STREQUAL "latest")
   set(PDFIUM_URL "https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-windows-${ARCH}.zip")


### PR DESCRIPTION
A number of assets seem to have been deleted from the release view of the pdfium-binaries repository. This sets the version to one that still exists.