### PR TITLE
Make zoom scale customizable

### DIFF
--- a/packages/pdfx/README.md
+++ b/packages/pdfx/README.md
@@ -82,6 +82,8 @@ PdfView(
 | pageSnapping     	| Set to false for mouse wheel scroll on web                                                                     | - / +                  |
 | physics          	| How the widgets should respond to user input                                                                   | - / +                  |
 | padding          	| Padding for the every page.                                                                                    | + / -                  |
+| minScale          | The minimum document zoom scale.                                                                               | + / -                  |
+| maxScale          | The maximum document zoom scale.                                                                               | + / -                  |
 
 ### PdfViewBuilders & PdfViewPinchBuilders
 
@@ -109,7 +111,7 @@ pdfController.jumpTo(3);
 // Animate to specified page
 _pdfController.animateToPage(3, duration: Duration(milliseconds: 250), curve: Curves.ease);
 
-// Animate to next page 
+// Animate to next page
 _pdfController.nextPage(duration: Duration(milliseconds: 250), curve: Curves.easeIn);
 
 // Animate to previous page

--- a/packages/pdfx/lib/src/viewer/pinch/pdf_view_pinch.dart
+++ b/packages/pdfx/lib/src/viewer/pinch/pdf_view_pinch.dart
@@ -31,6 +31,8 @@ class PdfViewPinch extends StatefulWidget {
     ),
     this.scrollDirection = Axis.vertical,
     this.padding = 10,
+    this.minScale = 1.0,
+    this.maxScale = 20.0,
     this.backgroundDecoration = const BoxDecoration(
       color: Color.fromARGB(255, 250, 250, 250),
       boxShadow: [
@@ -46,6 +48,12 @@ class PdfViewPinch extends StatefulWidget {
 
   /// Padding for the every page.
   final double padding;
+
+  /// The minimum document zoom scale.
+  final double minScale;
+
+  /// The maximum document zoom scale.
+  final double maxScale;
 
   /// Page management
   final PdfControllerPinch controller;
@@ -91,6 +99,8 @@ class _PdfViewPinchState extends State<PdfViewPinch>
   bool _forceUpdatePagePreviews = true;
 
   double get _padding => widget.padding;
+  double get _minScale => widget.minScale;
+  double get _maxScale => widget.maxScale;
 
   @override
   void initState() {
@@ -548,8 +558,8 @@ class _PdfViewPinchState extends State<PdfViewPinch>
           constrained: false,
           alignPanAxis: false,
           boundaryMargin: const EdgeInsets.all(double.infinity),
-          minScale: 0.25,
-          maxScale: 20,
+          minScale: _minScale,
+          maxScale: _maxScale,
           panEnabled: true,
           scaleEnabled: true,
           child: SafeArea(

--- a/packages/pdfx/lib/src/viewer/pinch/pdf_view_pinch.dart
+++ b/packages/pdfx/lib/src/viewer/pinch/pdf_view_pinch.dart
@@ -557,7 +557,9 @@ class _PdfViewPinchState extends State<PdfViewPinch>
           scrollControls: InteractiveViewerScrollControls.scrollPans,
           constrained: false,
           alignPanAxis: false,
-          boundaryMargin: const EdgeInsets.all(double.infinity),
+          boundaryMargin: _minScale < 1
+              ? const EdgeInsets.all(double.infinity)
+              : EdgeInsets.zero,
           minScale: _minScale,
           maxScale: _maxScale,
           panEnabled: true,


### PR DESCRIPTION
PR #487 changed the default zoom behavior (`minScale` and `boundaryMargin`). However, the new values seem to be for a specific use case and not desirable for standard PDFs. Version `2.6.0` had a much nicer default behavior.

This PR exposes these settings to allow for customization of these values:
```
PdfViewPinch(
  controller: pdfPinchController,
  minScale: 0.25,
  maxScale: 10.0,
);
```